### PR TITLE
Add support for Identity Verification

### DIFF
--- a/lib/plaid/identity_verification.ex
+++ b/lib/plaid/identity_verification.ex
@@ -1,0 +1,367 @@
+defmodule Plaid.IdentityVerification do
+  @moduledoc """
+  [Plaid Identity Verification API](https://plaid.com/docs/api/products/identity-verification) calls and schema.
+  """
+
+  alias Plaid.Castable
+  alias Plaid.IdentityVerification
+
+  alias Plaid.IdentityVerification.{
+    DocumentaryVerification,
+    KycCheck,
+    RiskCheck,
+    SelfieCheck,
+    Steps,
+    Template,
+    User
+  }
+
+  @behaviour Castable
+
+  @type create_params :: %{
+          client_user_id: String.t(),
+          is_shareable: boolean(),
+          template_id: String.t(),
+          gave_consent: boolean(),
+          user: %{
+            optional(:email_address) => String.t(),
+            optional(:phone_number) => String.t(),
+            optional(:date_of_birth) => String.t(),
+            optional(:name) => %{
+              given_name: String.t(),
+              family_name: String.t()
+            },
+            optional(:address) => %{
+              :street => String.t(),
+              optional(:street2) => String.t(),
+              optional(:city) => String.t(),
+              optional(:region) => String.t(),
+              optional(:postal_code) => String.t(),
+              country: String.t()
+            },
+            optional(:id_number) => %{
+              value: String.t(),
+              type: String.t()
+            }
+          },
+          is_idempotent: boolean() | nil
+        }
+
+  @type list_params :: %{
+          template_id: String.t(),
+          client_user_id: String.t(),
+          cursor: String.t() | nil
+        }
+
+  @type retry_params :: %{
+          client_user_id: String.t(),
+          template_id: String.t(),
+          strategy: String.t(),
+          user: User.t() | nil,
+          steps:
+            %{
+              verify_sms: boolean(),
+              kyc_check: boolean(),
+              documentary_verification: boolean(),
+              selfie_check: boolean()
+            }
+            | nil,
+          is_shareable: boolean() | nil
+        }
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          client_user_id: String.t(),
+          created_at: String.t(),
+          completed_at: String.t() | nil,
+          previous_attempt_id: String.t() | nil,
+          shareable_url: String.t() | nil,
+          template: Template.t(),
+          user: User.t(),
+          status: String.t(),
+          steps: Steps.t(),
+          documentary_verification: DocumentaryVerification.t() | nil,
+          selfie_check: SelfieCheck.t() | nil,
+          kyc_check: KycCheck.t() | nil,
+          risk_check: RiskCheck.t() | nil,
+          watchlist_screening_id: String.t() | nil,
+          redacted_at: String.t() | nil,
+          request_id: String.t()
+        }
+
+  defstruct [
+    :id,
+    :client_user_id,
+    :created_at,
+    :completed_at,
+    :previous_attempt_id,
+    :shareable_url,
+    :template,
+    :user,
+    :status,
+    :steps,
+    :documentary_verification,
+    :selfie_check,
+    :kyc_check,
+    :risk_check,
+    :watchlist_screening_id,
+    :redacted_at,
+    :request_id
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      id: generic_map["id"],
+      client_user_id: generic_map["client_user_id"],
+      created_at: generic_map["created_at"],
+      completed_at: generic_map["completed_at"],
+      previous_attempt_id: generic_map["previous_attempt_id"],
+      shareable_url: generic_map["shareable_url"],
+      template: Castable.cast(Template, generic_map["template"]),
+      user: Castable.cast(User, generic_map["user"]),
+      status: generic_map["status"],
+      steps: Castable.cast(Steps, generic_map["steps"]),
+      documentary_verification:
+        Castable.cast(DocumentaryVerification, generic_map["documentary_verification"]),
+      selfie_check: Castable.cast(SelfieCheck, generic_map["selfie_check"]),
+      kyc_check: Castable.cast(KycCheck, generic_map["kyc_check"]),
+      risk_check: Castable.cast(RiskCheck, generic_map["risk_check"]),
+      watchlist_screening_id: generic_map["watchlist_screenng_id"],
+      redacted_at: generic_map["redacted_at"],
+      request_id: generic_map["request_id"]
+    }
+  end
+
+  @doc """
+  [Creates and returns a new Identity Verification for the user specified by `client_user_id`.](https://plaid.com/docs/api/products/identity-verification/#identity_verificationcreate)
+
+  Makes a `POST /identity_verification/create` request.
+
+  Params:
+  * `client_user_id` - Your system's unique ID for this user.
+  * `is_shareable` - Whether Plaid should expose a shareable URL.
+  * `template_id` - Verification template to use.
+  * `gave_consent` - Whether user has already accepted a privacy policy.
+  * `user` - User information you've already collected, so Plaid doesn't re-collect
+             the same information. Includes:
+    * `email_address`
+    * `phone_number` - in E.164 format.
+    * `date_of_birth` - in YYYY-MM-DD format.
+    * `name`
+      * `given_name` - max 100 characters.
+      * `family_name` - max 100 characters.
+    * `address`
+      * `street` - max 80 characters.
+      * `street2` - max 50 characters.
+      * `city` - max 100 characters.
+      * `region` - ISO 3166-2.
+      * `postal_code`
+      * `country` - capitalized two-letter code, ISO 3166-1 alpha-2.
+    * `id_number`
+      * `value`
+      * `type` - what `value` represents, e.g. "us_ssn_last_4".
+  * `is_idempotent` - If an Identity Verification alreaady exists for this user,
+                      this field tells Plaid whether to return that verification
+                      (`is_idempotent`: true) or return a 400 Bad Request
+                      (`is_idempotent`: false).
+
+  ## Examples
+
+      Plaid.IdentityVerification.create(
+        %{
+          client_user_id: "user-sandbox-b0e2c4ee-a763-4df5-bfe9-46a46bce993d",
+          is_shareable: true,
+          template_id: "idvtmp_52xR9LKo77r1Np",
+          gave_consent: true,
+          user: %{
+            email_address: "acharleston@email.com",
+            phone_number: "+11234567890",
+            date_of_birth: "1975-01-18",
+            name: %{
+              given_name: "Anna",
+              family_name: "Charleston"
+            },
+            address: %{
+              street: "100 Market Street",
+              street2: "Apt 1A",
+              city: "San Francisco",
+              region: "CA",
+              postal_code: "94103",
+              country: "US"
+            },
+            id_number: %{
+              value: "123456789",
+              type: "us_ssn"
+            }
+          }
+        },
+        client_id: "123",
+        secret: "abc"
+      )
+      {:ok, %Plaid.IdentityVerification{}}
+
+  """
+  @spec create(create_params(), Plaid.config()) ::
+          {:ok, IdentityVerification.t()} | {:error, Plaid.Error.t()}
+  def create(payload, config) do
+    Plaid.Client.call("/identity_verification/create", payload, IdentityVerification, config)
+  end
+
+  @doc """
+  [Retrieves a previously created Identity Verification by its id.](https://plaid.com/docs/api/products/identity-verification/#identity_verificationget)
+
+  Makes a `POST /identity_verification/get` request.
+
+  Params:
+  * `identity_verification_id` - id of an Identity Verification attempt.
+
+  ## Examples:
+
+      Plaid.IdentityVerification.get("idv_52xR9LKo77r1Np", client_id: "123", secret: "abc")
+      {:ok, %Plaid.IdentityVerification{}}
+
+  """
+
+  @spec get(String.t(), Plaid.config()) ::
+          {:ok, IdentityVerification.t()} | {:error, Plaid.Error.t()}
+  def get(identity_verification_id, config) do
+    Plaid.Client.call(
+      "/identity_verification/get",
+      %{identity_verification_id: identity_verification_id},
+      IdentityVerification,
+      config
+    )
+  end
+
+  defmodule ListResponse do
+    @moduledoc """
+    [Plaid API /identity_verifications/list response schema.](https://plaid.com/docs/api/products/identity-verification/#identity_verificationlist)
+    """
+    @behaviour Castable
+
+    @type t :: %__MODULE__{
+            identity_verifications: [Plaid.IdentityVerification.t()],
+            next_cursor: String.t() | nil,
+            request_id: String.t()
+          }
+
+    defstruct [:identity_verifications, :next_cursor, :request_id]
+
+    @impl true
+    def cast(generic_map) do
+      %__MODULE__{
+        identity_verifications:
+          Castable.cast_list(IdentityVerification, generic_map["identity_verifications"]),
+        next_cursor: generic_map["next_cursor"],
+        request_id: generic_map["request_id"]
+      }
+    end
+  end
+
+  @doc """
+  [Returns a paginated list of Identity Verifications for a given user and template.](https://plaid.com/docs/api/products/identity-verification/#identity_verificationlist)
+
+  Makes a `POST /identity_verification/list` request.
+
+  Params:
+  * `template_id` - Identity Verification template which you've set up on Plaid.
+  * `client_user_id` - Your system's unique ID for this user.
+  * `cursor` - Determines which page of results you'll receive. Each page
+               returns a `next_cursor` you can use to get the next page.
+
+  ## Examples:
+
+      Plaid.IdentityVerification.list(
+        %{
+          template_id: "idvtmp_52xR9LKo77r1Np",
+          client_user_id: "user-sandbox-b0e2c4ee-a763-4df5-bfe9-46a46bce993d",
+        },
+        client_id: "123",
+        secret: "abc"
+      )
+      {:ok, Plaid.IdentityVerification.ListResponse{}}
+
+  """
+  @spec list(list_params(), Plaid.config()) :: {:ok, ListResponse.t()} | {:error, Plaid.Error.t()}
+  def list(params, config) do
+    Plaid.Client.call("/identity_verification/list", params, ListResponse, config)
+  end
+
+  @doc """
+  [Allows a customer to retry their Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verificationretry)
+
+  Makes a `POST /identity_verification/retry` request.
+
+  Params:
+  * `client_user_id` - Your system's unique ID for this user.
+  * `template_id` - Identity Verification template which you've set up on Plaid.
+  * `strategy` - One of "reset", "incomplete", "infer", or "custom", indicating
+                 which steps should be retried,
+  * `user` - User information you've already collected, so Plaid doesn't re-collect
+             the same information. Includes:
+    * `email_address`
+    * `phone_number` - in E.164 format.
+    * `date_of_birth` - in YYYY-MM-DD format.
+    * `name`
+      * `given_name` - max 100 characters.
+      * `family_name` - max 100 characters.
+    * `address`
+      * `street` - max 80 characters.
+      * `street2` - max 50 characters.
+      * `city` - max 100 characters.
+      * `region` - ISO 3166-2.
+      * `postal_code`
+      * `country` - capitalized two-letter code, ISO 3166-1 alpha-2.
+    * `id_number`
+      * `value`
+      * `type` - what `value` represents, e.g. "us_ssn_last_4".
+  * `steps` - When `strategy` is "custom", specifies which steps to require.
+              Includes boolean params:
+    * `verify_sms`
+    * `kyc_check`
+    * `documentary_verification`
+    * `selfie_check`
+  * `is_shareable` - Whether Plaid should expose a shareable URL.
+
+  ## Examples
+
+      Plaid.IdentityVerification.retry(
+        %{
+          client_user_id: "user-sandbox-b0e2c4ee-a763-4df5-bfe9-46a46bce993d",
+          template_id: "idvtmp_52xR9LKo77r1Np",
+          strategy: "reset",
+          user: %{
+            email_address: "acharleston@email.com",
+            phone_number: "+11234567890",
+            date_of_birth: "1975-01-18",
+            name: %{
+              given_name: "Anna",
+              family_name: "Charleston"
+            },
+            address: %{
+              street: "100 Market Street",
+              street2: "Apt 1A",
+              city: "San Francisco",
+              region: "CA",
+              postal_code: "94103",
+              country: "US"
+            },
+            id_number: %{
+              value: "123456789",
+              type: "us_ssn"
+            }
+          }
+        },
+        client_id: "123",
+        secret: "abc"
+      )
+      {:ok, %Plaid.IdentityVerification{}}
+
+  """
+  @spec retry(retry_params(), Plaid.config()) ::
+          {:ok, IdentityVerification.t()} | {:error, Plaid.Error.t()}
+  def retry(params, config) do
+    Plaid.Client.call("/identity_verification/retry", params, IdentityVerification, config)
+  end
+end

--- a/lib/plaid/identity_verification/documentary_verification.ex
+++ b/lib/plaid/identity_verification/documentary_verification.ex
@@ -1,0 +1,25 @@
+defmodule Plaid.IdentityVerification.DocumentaryVerification do
+  @moduledoc """
+  [Data from the documentary verification step of Plaid Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-documentary-verification)
+  """
+
+  alias Plaid.Castable
+  alias Plaid.IdentityVerification.DocumentaryVerification.Document
+
+  @behaviour Castable
+
+  @type t :: %__MODULE__{
+          status: String.t(),
+          documents: [Document.t()]
+        }
+
+  defstruct [:status, :documents]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      status: generic_map["status"],
+      documents: Castable.cast_list(Document, generic_map["documents"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/documentary_verification/document.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document.ex
@@ -1,0 +1,38 @@
+defmodule Plaid.IdentityVerification.DocumentaryVerification.Document do
+  @moduledoc """
+  [A single user submission to the documentary verification step of Plaid Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-documentary-verification-documents)
+  """
+
+  alias Plaid.Castable
+
+  alias Plaid.IdentityVerification.DocumentaryVerification.Document.{
+    Analysis,
+    ExtractedData,
+    Image
+  }
+
+  @behaviour Castable
+
+  @type t :: %__MODULE__{
+          status: String.t(),
+          attempt: integer(),
+          images: [Image.t()],
+          extracted_data: ExtractedData.t(),
+          analysis: Analysis.t(),
+          redacted_at: String.t() | nil
+        }
+
+  defstruct [:status, :attempt, :images, :extracted_data, :analysis, :redacted_at]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      status: generic_map["status"],
+      attempt: generic_map["attempt"],
+      images: Castable.cast_list(Image, generic_map["images"]),
+      extracted_data: Castable.cast(ExtractedData, generic_map["extracted_data"]),
+      analysis: Castable.cast(Analysis, generic_map["analysis"]),
+      redacted_at: generic_map["redacted_at"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/documentary_verification/document.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document.ex
@@ -8,7 +8,7 @@ defmodule Plaid.IdentityVerification.DocumentaryVerification.Document do
   alias Plaid.IdentityVerification.DocumentaryVerification.Document.{
     Analysis,
     ExtractedData,
-    Image
+    Images
   }
 
   @behaviour Castable
@@ -16,7 +16,7 @@ defmodule Plaid.IdentityVerification.DocumentaryVerification.Document do
   @type t :: %__MODULE__{
           status: String.t(),
           attempt: integer(),
-          images: [Image.t()],
+          images: [Images.t()],
           extracted_data: ExtractedData.t(),
           analysis: Analysis.t(),
           redacted_at: String.t() | nil
@@ -29,7 +29,7 @@ defmodule Plaid.IdentityVerification.DocumentaryVerification.Document do
     %__MODULE__{
       status: generic_map["status"],
       attempt: generic_map["attempt"],
-      images: Castable.cast_list(Image, generic_map["images"]),
+      images: Castable.cast(Images, generic_map["images"]),
       extracted_data: Castable.cast(ExtractedData, generic_map["extracted_data"]),
       analysis: Castable.cast(Analysis, generic_map["analysis"]),
       redacted_at: generic_map["redacted_at"]

--- a/lib/plaid/identity_verification/documentary_verification/document/analysis.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document/analysis.ex
@@ -1,0 +1,28 @@
+defmodule Plaid.IdentityVerification.DocumentaryVerification.Document.Analysis do
+  @moduledoc """
+  [Analysis of how a document was processed for Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-documentary-verification-documents-analysis)
+  """
+
+  alias Plaid.Castable
+
+  @behaviour Castable
+
+  alias Plaid.IdentityVerification.DocumentaryVerification.Document.Analysis.ExtractedData
+
+  @type t :: %__MODULE__{
+          authenticity: String.t(),
+          image_quality: String.t(),
+          extracted_data: ExtractedData.t() | nil
+        }
+
+  defstruct [:authenticity, :image_quality, :extracted_data]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      authenticity: generic_map["authenticity"],
+      image_quality: generic_map["image_quality"],
+      extracted_data: Castable.cast(ExtractedData, generic_map["extracted_data"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/documentary_verification/document/analysis/extracted_data.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document/analysis/extracted_data.ex
@@ -1,0 +1,26 @@
+defmodule Plaid.IdentityVerification.DocumentaryVerification.Document.Analysis.ExtractedData do
+  @moduledoc """
+  [Abbreviated list of data extracted by OCR from a submitted document, used for analysis.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-documentary-verification-documents-analysis-extracted-data)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          date_of_birth: String.t(),
+          expiration_date: String.t(),
+          issuing_country: String.t()
+        }
+
+  defstruct [:name, :date_of_birth, :expiration_date, :issuing_country]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      name: generic_map["name"],
+      date_of_birth: generic_map["date_of_birth"],
+      expiration_date: generic_map["expiration_date"],
+      issuing_country: generic_map["issuing_country"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/documentary_verification/document/extracted_data.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document/extracted_data.ex
@@ -1,0 +1,47 @@
+defmodule Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedData do
+  @moduledoc """
+  [Data extracted by OCR from a document submitted for Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-documentary-verification-documents-extracted-data)
+  """
+
+  alias Plaid.Castable
+  alias Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedData.Address
+  alias Plaid.IdentityVerification.DocumentaryVerification.User.Name
+
+  @behaviour Castable
+
+  @type t :: %__MODULE__{
+          id_number: String.t() | nil,
+          category: String.t(),
+          expiration_date: String.t() | nil,
+          issuing_country: String.t(),
+          issuing_region: String.t() | nil,
+          date_of_birth: String.t() | nil,
+          address: Address.t() | nil,
+          name: Name.t() | nil
+        }
+
+  defstruct [
+    :id_number,
+    :category,
+    :expiration_date,
+    :issuing_country,
+    :issuing_region,
+    :date_of_birth,
+    :address,
+    :name
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      id_number: generic_map["id_number"],
+      category: generic_map["category"],
+      expiration_date: generic_map["expiration_date"],
+      issuing_country: generic_map["issuing_country"],
+      issuing_region: generic_map["issuing_region"],
+      date_of_birth: generic_map["date_of_birth"],
+      address: Castable.cast(Address, generic_map["address"]),
+      name: Castable.cast(Name, generic_map["name"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/documentary_verification/document/extracted_data.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document/extracted_data.ex
@@ -5,7 +5,7 @@ defmodule Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedD
 
   alias Plaid.Castable
   alias Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedData.Address
-  alias Plaid.IdentityVerification.DocumentaryVerification.User.Name
+  alias Plaid.IdentityVerification.User.Name
 
   @behaviour Castable
 

--- a/lib/plaid/identity_verification/documentary_verification/document/extracted_data/address.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document/extracted_data/address.ex
@@ -1,0 +1,29 @@
+defmodule Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedData.Address do
+  @moduledoc """
+  [An address extracted from a submitted document during Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-documentary-verification-documents-extracted-data-address)
+  The same as `Plaid.Address` except that `street`, `city`, and `country` are required.
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          street: String.t(),
+          city: String.t(),
+          region: String.t() | nil,
+          postal_code: String.t() | nil,
+          country: String.t()
+        }
+
+  defstruct [:street, :city, :region, :postal_code, :country]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      street: generic_map["street"],
+      city: generic_map["city"],
+      region: generic_map["region"],
+      postal_code: generic_map["postal_code"],
+      country: generic_map["country"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/documentary_verification/document/image.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document/image.ex
@@ -1,0 +1,28 @@
+defmodule Plaid.IdentityVerification.DocumentaryVerification.Document.Image do
+  @moduledoc """
+  [URLs for an image submitted for Plaid Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-documentary-verification-documents-images)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          original_front: String.t() | nil,
+          original_back: String.t() | nil,
+          cropped_front: String.t() | nil,
+          cropped_back: String.t() | nil,
+          face: String.t() | nil
+        }
+
+  defstruct [:original_front, :original_back, :cropped_front, :cropped_back, :face]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      original_front: generic_map["original_front"],
+      original_back: generic_map["original_back"],
+      cropped_front: generic_map["cropped_front"],
+      cropped_back: generic_map["cropped_back"],
+      face: generic_map["face"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/documentary_verification/document/images.ex
+++ b/lib/plaid/identity_verification/documentary_verification/document/images.ex
@@ -1,4 +1,4 @@
-defmodule Plaid.IdentityVerification.DocumentaryVerification.Document.Image do
+defmodule Plaid.IdentityVerification.DocumentaryVerification.Document.Images do
   @moduledoc """
   [URLs for an image submitted for Plaid Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-documentary-verification-documents-images)
   """

--- a/lib/plaid/identity_verification/kyc_check.ex
+++ b/lib/plaid/identity_verification/kyc_check.ex
@@ -1,0 +1,33 @@
+defmodule Plaid.IdentityVerification.KycCheck do
+  @moduledoc """
+  [Additional information for the kyc_check step of Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-kyc-check)
+  """
+
+  alias Plaid.Castable
+  alias Plaid.IdentityVerification.KycCheck.{Address, DateOfBirth, IdNumber, Name, PhoneNumber}
+
+  @behaviour Castable
+
+  @type t :: %{
+          status: String.t(),
+          address: Address.t(),
+          name: Name.t(),
+          date_of_birth: DateOfBirth.t(),
+          id_number: IdNumber.t(),
+          phone_number: PhoneNumber.t()
+        }
+
+  defstruct [:status, :address, :name, :date_of_birth, :id_number, :phone_number]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      status: generic_map["status"],
+      address: Castable.cast(Address, generic_map["address"]),
+      name: Castable.cast(Name, generic_map["name"]),
+      date_of_birth: Castable.cast(DateOfBirth, generic_map["date_of_birth"]),
+      id_number: Castable.cast(IdNumber, generic_map["id_number"]),
+      phone_number: Castable.cast(PhoneNumber, generic_map["phone_number"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/kyc_check/address.ex
+++ b/lib/plaid/identity_verification/kyc_check/address.ex
@@ -1,0 +1,24 @@
+defmodule Plaid.IdentityVerification.KycCheck.Address do
+  @moduledoc """
+  [Summary of how address field matched during KYC check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-kyc-check-address)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          summary: String.t(),
+          po_box: String.t(),
+          type: String.t()
+        }
+
+  defstruct [:summary, :po_box, :type]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      summary: generic_map["summary"],
+      po_box: generic_map["po_box"],
+      type: generic_map["type"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/kyc_check/date_of_birth.ex
+++ b/lib/plaid/identity_verification/kyc_check/date_of_birth.ex
@@ -1,0 +1,20 @@
+defmodule Plaid.IdentityVerification.KycCheck.DateOfBirth do
+  @moduledoc """
+  [Summary of how date_of_birth field matched during KYC check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-kyc-check-date-of-birth)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          summary: String.t()
+        }
+
+  defstruct [:summary]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      summary: generic_map["summary"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/kyc_check/id_number.ex
+++ b/lib/plaid/identity_verification/kyc_check/id_number.ex
@@ -1,0 +1,20 @@
+defmodule Plaid.IdentityVerification.KycCheck.IdNumber do
+  @moduledoc """
+  [Summary of how id_number field matched during KYC check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-kyc-check-id-number)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          summary: String.t()
+        }
+
+  defstruct [:summary]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      summary: generic_map["summary"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/kyc_check/name.ex
+++ b/lib/plaid/identity_verification/kyc_check/name.ex
@@ -1,0 +1,20 @@
+defmodule Plaid.IdentityVerification.KycCheck.Name do
+  @moduledoc """
+  [Summary of how name field matched during KYC check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-kyc-check-name)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          summary: String.t()
+        }
+
+  defstruct [:summary]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      summary: generic_map["summary"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/kyc_check/phone_number.ex
+++ b/lib/plaid/identity_verification/kyc_check/phone_number.ex
@@ -1,0 +1,22 @@
+defmodule Plaid.IdentityVerification.KycCheck.PhoneNumber do
+  @moduledoc """
+  [Summary of how phone field matched during KYC check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-kyc-check-phone-number)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          summary: String.t(),
+          area_code: String.t()
+        }
+
+  defstruct [:summary, :area_code]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      summary: generic_map["summary"],
+      area_code: generic_map["area_code"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/risk_check.ex
+++ b/lib/plaid/identity_verification/risk_check.ex
@@ -1,0 +1,41 @@
+defmodule Plaid.IdentityVerification.RiskCheck do
+  @moduledoc """
+  [Additional information for risk_check step of Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-risk-check)
+  """
+
+  alias Plaid.Castable
+
+  alias Plaid.IdentityVerification.RiskCheck.{
+    Behavior,
+    Device,
+    Email,
+    IdentityAbuseSignals,
+    Phone
+  }
+
+  @behaviour Castable
+
+  @type t :: %__MODULE__{
+          status: String.t(),
+          behavior: Behavior.t() | nil,
+          email: Email.t() | nil,
+          phone: Phone.t() | nil,
+          devices: [Device.t()],
+          identity_abuse_signals: IdentityAbuseSignals.t() | nil
+        }
+
+  defstruct [:status, :behavior, :email, :phone, :devices, :identity_abuse_signals]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      status: generic_map["status"],
+      behavior: Castable.cast(Behavior, generic_map["behavior"]),
+      email: Castable.cast(Email, generic_map["email"]),
+      phone: Castable.cast(Phone, generic_map["phone"]),
+      devices: Castable.cast_list(Device, generic_map["devices"]),
+      identity_abuse_signals:
+        Castable.cast(IdentityAbuseSignals, generic_map["identity_abuse_signals"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/risk_check/behavior.ex
+++ b/lib/plaid/identity_verification/risk_check/behavior.ex
@@ -1,0 +1,24 @@
+defmodule Plaid.IdentityVerification.RiskCheck.Behavior do
+  @moduledoc """
+  [Summary of behavior attributes for risk check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-risk-check-behavior)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          user_interactions: String.t(),
+          fraud_ring_detected: String.t(),
+          bot_detected: String.t()
+        }
+
+  defstruct [:user_interactions, :fraud_ring_detected, :bot_detected]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      user_interactions: generic_map["user_interactions"],
+      fraud_ring_detected: generic_map["fraud_ring_detected"],
+      bot_detected: generic_map["bot_detected"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/risk_check/device.ex
+++ b/lib/plaid/identity_verification/risk_check/device.ex
@@ -1,0 +1,24 @@
+defmodule Plaid.IdentityVerification.RiskCheck.Device do
+  @moduledoc """
+  [Summary of device attributes for risk check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-risk-check-devices)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          ip_proxy_type: String.t() | nil,
+          ip_spam_list_count: integer() | nil,
+          ip_timezone_offset: String.t() | nil
+        }
+
+  defstruct [:ip_proxy_type, :ip_spam_list_count, :ip_timezone_offset]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      ip_proxy_type: generic_map["ip_proxy_type"],
+      ip_spam_list_count: generic_map["ip_spam_list_count"],
+      ip_timezone_offset: generic_map["ip_timezone_offset"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/risk_check/email.ex
+++ b/lib/plaid/identity_verification/risk_check/email.ex
@@ -1,0 +1,49 @@
+defmodule Plaid.IdentityVerification.RiskCheck.Email do
+  @moduledoc """
+  [Summary of email attributes for risk check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-risk-check-email)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          is_deliverable: String.t(),
+          breach_count: integer() | nil,
+          first_breached_at: String.t() | nil,
+          last_breached_at: String.t() | nil,
+          domain_registered_at: String.t() | nil,
+          domain_is_free_provider: String.t(),
+          domain_is_custom: String.t(),
+          domain_is_disposable: String.t(),
+          top_level_domain_is_suspicious: String.t(),
+          linked_services: [String.t()]
+        }
+
+  defstruct [
+    :is_deliverable,
+    :breach_count,
+    :first_breached_at,
+    :last_breached_at,
+    :domain_registered_at,
+    :domain_is_free_provider,
+    :domain_is_custom,
+    :domain_is_disposable,
+    :top_level_domain_is_suspicious,
+    :linked_services
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      is_deliverable: generic_map["is_deliverable"],
+      breach_count: generic_map["breach_count"],
+      first_breached_at: generic_map["first_breached_at"],
+      last_breached_at: generic_map["last_breached_at"],
+      domain_registered_at: generic_map["domain_registered_at"],
+      domain_is_free_provider: generic_map["domain_is_free_provider"],
+      domain_is_custom: generic_map["domain_is_custom"],
+      domain_is_disposable: generic_map["domain_is_disposable"],
+      top_level_domain_is_suspicious: generic_map["top_level_domain_is_suspicious"],
+      linked_services: generic_map["linked_services"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/risk_check/identity_abuse_signals.ex
+++ b/lib/plaid/identity_verification/risk_check/identity_abuse_signals.ex
@@ -1,0 +1,29 @@
+defmodule Plaid.IdentityVerification.RiskCheck.IdentityAbuseSignals do
+  @moduledoc """
+  [Summary of risk check signals related to identity fraud.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-risk-check-identity-abuse-signals)
+  """
+
+  alias Plaid.Castable
+
+  alias Plaid.IdentityVerification.RiskCheck.IdentityAbuseSignals.{
+    StolenIdentity,
+    SyntheticIdentity
+  }
+
+  @behaviour Castable
+
+  @type t :: %__MODULE__{
+          synthetic_identity: SyntheticIdentity.t() | nil,
+          stolen_identity: StolenIdentity.t() | nil
+        }
+
+  defstruct [:synthetic_identity, :stolen_identity]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      synthetic_identity: Castable.cast(SyntheticIdentity, generic_map["synthetic_identity"]),
+      stolen_identity: Castable.cast(StolenIdentity, generic_map["stolen_identity"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/risk_check/identity_abuse_signals/stolen_identity.ex
+++ b/lib/plaid/identity_verification/risk_check/identity_abuse_signals/stolen_identity.ex
@@ -1,0 +1,18 @@
+defmodule Plaid.IdentityVerification.RiskCheck.IdentityAbuseSignals.StolenIdentity do
+  @moduledoc """
+  [Data used in stolen identity risk check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-risk-check-identity-abuse-signals-stolen-identity)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          score: integer()
+        }
+
+  defstruct [:score]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{score: generic_map["score"]}
+  end
+end

--- a/lib/plaid/identity_verification/risk_check/identity_abuse_signals/synthetic_identity.ex
+++ b/lib/plaid/identity_verification/risk_check/identity_abuse_signals/synthetic_identity.ex
@@ -1,0 +1,18 @@
+defmodule Plaid.IdentityVerification.RiskCheck.IdentityAbuseSignals.SyntheticIdentity do
+  @moduledoc """
+  [Data used in synthetic identity risk check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-risk-check-identity-abuse-signals-synthetic-identity)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          score: integer()
+        }
+
+  defstruct [:score]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{score: generic_map["score"]}
+  end
+end

--- a/lib/plaid/identity_verification/risk_check/phone.ex
+++ b/lib/plaid/identity_verification/risk_check/phone.ex
@@ -1,0 +1,20 @@
+defmodule Plaid.IdentityVerification.RiskCheck.Phone do
+  @moduledoc """
+  [Summary of phone attributes for risk check.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-risk-check-phone)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          linked_services: [String.t()]
+        }
+
+  defstruct [:linked_services]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      linked_services: generic_map["linked_services"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/selfie_check.ex
+++ b/lib/plaid/identity_verification/selfie_check.ex
@@ -1,0 +1,25 @@
+defmodule Plaid.IdentityVerification.SelfieCheck do
+  @moduledoc """
+  [Additional information for the selfie_check step of Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-selfie-check)
+  """
+
+  alias Plaid.Castable
+  alias Plaid.IdentityVerification.SelfieCheck.Selfie
+
+  @behaviour Castable
+
+  @type t :: %__MODULE__{
+          status: String.t(),
+          selfies: [Selfie.t()]
+        }
+
+  defstruct [:status, :selfies]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      status: generic_map["status"],
+      selfies: Castable.cast_list(Selfie, generic_map["selfies"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/selfie_check/selfie.ex
+++ b/lib/plaid/identity_verification/selfie_check/selfie.ex
@@ -1,0 +1,29 @@
+defmodule Plaid.IdentityVerification.SelfieCheck.Selfie do
+  @moduledoc """
+  [A selfie submitted to selfie_check for Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-selfie-check-selfies)
+  """
+
+  alias Plaid.Castable
+  alias Plaid.IdentityVerification.SelfieCheck.Selfie.{Capture, Analysis}
+
+  @behaviour Castable
+
+  @type t :: %__MODULE__{
+          status: String.t(),
+          attempt: integer(),
+          capture: Capture.t(),
+          analysis: Analysis.t()
+        }
+
+  defstruct [:status, :attempt, :capture, :analysis]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      status: generic_map["status"],
+      attempt: generic_map["attempt"],
+      capture: Castable.cast(Capture, generic_map["capture"]),
+      analysis: Castable.cast(Analysis, generic_map["analysis"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/selfie_check/selfie/analysis.ex
+++ b/lib/plaid/identity_verification/selfie_check/selfie/analysis.ex
@@ -1,0 +1,20 @@
+defmodule Plaid.IdentityVerification.SelfieCheck.Selfie.Analysis do
+  @moduledoc """
+  [Analysis of the verification of a submitted selfie.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-selfie-check-selfies-analysis)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          document_comparison: String.t()
+        }
+
+  defstruct [:document_comparison]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      document_comparison: generic_map["document_comparison"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/selfie_check/selfie/capture.ex
+++ b/lib/plaid/identity_verification/selfie_check/selfie/capture.ex
@@ -1,0 +1,22 @@
+defmodule Plaid.IdentityVerification.SelfieCheck.Selfie.Capture do
+  @moduledoc """
+  [Image or video URL of a submitted selfie.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-selfie-check-selfies-capture)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          image_url: String.t() | nil,
+          video_url: String.t() | nil
+        }
+
+  defstruct [:image_url, :video_url]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      image_url: generic_map["image_url"],
+      video_url: generic_map["video_url"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/steps.ex
+++ b/lib/plaid/identity_verification/steps.ex
@@ -1,0 +1,40 @@
+defmodule Plaid.IdentityVerification.Steps do
+  @moduledoc """
+  [How far the user has gotten in each step of Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-steps)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          accept_tos: String.t(),
+          verify_sms: String.t(),
+          kyc_check: String.t(),
+          documentary_verification: String.t(),
+          selfie_check: String.t(),
+          watchlist_screening: String.t(),
+          risk_check: String.t()
+        }
+
+  defstruct [
+    :accept_tos,
+    :verify_sms,
+    :kyc_check,
+    :documentary_verification,
+    :selfie_check,
+    :watchlist_screening,
+    :risk_check
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      accept_tos: generic_map["accept_tos"],
+      verify_sms: generic_map["verify_sms"],
+      kyc_check: generic_map["kyc_check"],
+      documentary_verification: generic_map["documentary_verification"],
+      selfie_check: generic_map["selfie_check"],
+      watchlist_screening: generic_map["watchlist_screening"],
+      risk_check: generic_map["risk_check"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/template.ex
+++ b/lib/plaid/identity_verification/template.ex
@@ -1,0 +1,22 @@
+defmodule Plaid.IdentityVerification.Template do
+  @moduledoc """
+  [Plaid Identity Verification template.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-template)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          version: integer()
+        }
+
+  defstruct [:id, :version]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      id: generic_map["id"],
+      version: generic_map["version"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/user.ex
+++ b/lib/plaid/identity_verification/user.ex
@@ -1,0 +1,43 @@
+defmodule Plaid.IdentityVerification.User do
+  @moduledoc """
+  [Plaid user schema for Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-user)
+  """
+
+  alias Plaid.Castable
+  alias Plaid.IdentityVerification.User.{Address, IdNumber, Name}
+
+  @behaviour Castable
+
+  @type t :: %__MODULE__{
+          phone_number: String.t() | nil,
+          date_of_birth: String.t() | nil,
+          ip_address: String.t() | nil,
+          email_address: String.t() | nil,
+          name: Name.t() | nil,
+          address: Address.t() | nil,
+          id_number: IdNumber.t() | nil
+        }
+
+  defstruct [
+    :phone_number,
+    :date_of_birth,
+    :ip_address,
+    :email_address,
+    :name,
+    :address,
+    :id_number
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      phone_number: generic_map["phone_number"],
+      date_of_birth: generic_map["date_of_birth"],
+      ip_address: generic_map["ip_address"],
+      email_address: generic_map["email_address"],
+      name: Castable.cast(Name, generic_map["name"]),
+      address: Castable.cast(Address, generic_map["address"]),
+      id_number: Castable.cast(IdNumber, generic_map["id_number"])
+    }
+  end
+end

--- a/lib/plaid/identity_verification/user/address.ex
+++ b/lib/plaid/identity_verification/user/address.ex
@@ -1,0 +1,30 @@
+defmodule Plaid.IdentityVerification.User.Address do
+  @moduledoc """
+  [User address schema for Plaid Identity Verification](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-user-address)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+    street: String.t(),
+    street2: String.t() | nil,
+    city: String.t() | nil,
+    region: String.t() | nil,
+    postal_code: String.t() | nil,
+    country: String.t()
+  }
+
+  defstruct [:street, :street2, :city, :region, :postal_code, :country]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      street: generic_map["street"],
+      street2: generic_map["street2"],
+      city: generic_map["city"],
+      region: generic_map["region"],
+      postal_code: generic_map["postal_code"],
+      country: generic_map["country"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/user/id_number.ex
+++ b/lib/plaid/identity_verification/user/id_number.ex
@@ -1,0 +1,22 @@
+defmodule Plaid.IdentityVerification.User.IdNumber do
+  @moduledoc """
+  [User's government ID for Plaid Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-user-id-number)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+    value: String.t(),
+    type: String.t()
+  }
+
+  defstruct [:value, :type]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      value: generic_map["value"],
+      type: generic_map["type"]
+    }
+  end
+end

--- a/lib/plaid/identity_verification/user/name.ex
+++ b/lib/plaid/identity_verification/user/name.ex
@@ -1,0 +1,22 @@
+defmodule Plaid.IdentityVerification.User.Name do
+  @moduledoc """
+  [User's name for Plaid Identity Verification.](https://plaid.com/docs/api/products/identity-verification/#identity_verification-create-response-user-name)
+  """
+
+  @behaviour Plaid.Castable
+
+  @type t :: %__MODULE__{
+    given_name: String.t(),
+    family_name: String.t()
+  }
+
+  defstruct [:given_name, :family_name]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      given_name: generic_map["given_name"],
+      family_name: generic_map["family_name"]
+    }
+  end
+end

--- a/lib/plaid/webhooks.ex
+++ b/lib/plaid/webhooks.ex
@@ -387,6 +387,36 @@ defmodule Plaid.Webhooks do
     end
   end
 
+  defmodule IdentityVerification do
+    @moduledoc """
+    [Plaid Identity Verification webhooks schema.](https://plaid.com/docs/api/products/identity-verification/#status_updated)
+
+    Used with `STATUS_UPDATED`, `STEP_UPDATED`, and `RETRIED` webhooks of type
+    `IDENTITY_VERIFICATION`.
+    """
+
+    @behaviour Castable
+
+    @type t :: %__MODULE__{
+            webhook_type: String.t(),
+            webhook_code: String.t(),
+            identity_verification_id: String.t(),
+            environment: String.t()
+          }
+
+    defstruct [:webhook_type, :webhook_code, :identity_verification_id, :environment]
+
+    @impl true
+    def cast(generic_map) do
+      %__MODULE__{
+        webhook_type: generic_map["webhook_type"],
+        webhook_code: generic_map["webhook_code"],
+        identity_verification_id: generic_map["identity_verification_id"],
+        environment: generic_map["environment"]
+      }
+    end
+  end
+
   defmodule InvestmentsTransactionsUpdate do
     @moduledoc """
     [Plaid INVESTMENTS_TRANSACTIONS: DEFAULT_UPDATE webhooks schema](https://plaid.com/docs/api/webhooks/#investments_transactions-default_update)
@@ -492,6 +522,9 @@ defmodule Plaid.Webhooks do
   defp struct_module("ASSETS", "PRODUCT_READY"), do: AssetsProductReady
   defp struct_module("ASSETS", "ERROR"), do: AssetsError
   defp struct_module("HOLDINGS", "DEFAULT_UPDATE"), do: HoldingsUpdate
+  defp struct_module("IDENTITY_VERIFICATION", "STATUS_UPDATED"), do: IdentityVerification
+  defp struct_module("IDENTITY_VERIFICATION", "STEP_UPDATED"), do: IdentityVerification
+  defp struct_module("IDENTITY_VERIFICATION", "RETRIED"), do: IdentityVerification
 
   defp struct_module("INVESTMENTS_TRANSACTIONS", "DEFAULT_UPDATE"),
     do: InvestmentsTransactionsUpdate

--- a/test/plaid/identity_verification_test.exs
+++ b/test/plaid/identity_verification_test.exs
@@ -1,0 +1,249 @@
+defmodule Plaid.IdentityVerificationTest do
+  use ExUnit.Case, async: true
+
+  alias Plug.Conn
+
+  setup do
+    bypass = Bypass.open()
+    api_host = "http://localhost:#{bypass.port}/"
+    {:ok, bypass: bypass, api_host: api_host}
+  end
+
+  test "/identity_verification/create", %{bypass: bypass, api_host: api_host} do
+    Bypass.expect_once(bypass, "POST", "/identity_verification/create", fn conn ->
+      Conn.resp(conn, 200, identity_verification_raw_response())
+    end)
+
+    assert {:ok, parsed_identity_verification()} ==
+             Plaid.IdentityVerification.create(
+               %{
+                 client_user_id: "user-id-202409051444",
+                 is_shareable: true,
+                 template_id: "idvtmp_4iwgqud9uH1BS7",
+                 gave_consent: true,
+                 user: %{
+                   email_address: "acharleston@email.com",
+                   phone_number: "+14155550010",
+                   date_of_birth: "1975-01-18",
+                   name: %{
+                     given_name: "Anna",
+                     family_name: "Charleston"
+                   },
+                   address: %{
+                     street: "100 Market Street",
+                     street2: "Apt 1A",
+                     city: "San Francisco",
+                     region: "CA",
+                     postal_code: "94103",
+                     country: "US"
+                   },
+                   id_number: %{
+                     value: "123456789",
+                     type: "us_ssn"
+                   }
+                 }
+               },
+               test_api_host: api_host,
+               client_id: "123",
+               secret: "abc"
+             )
+  end
+
+  test "/identity_verification/get", %{bypass: bypass, api_host: api_host} do
+    Bypass.expect_once(bypass, "POST", "/identity_verification/get", fn conn ->
+      Conn.resp(conn, 200, identity_verification_raw_response())
+    end)
+
+    assert {:ok, parsed_identity_verification()} ==
+             Plaid.IdentityVerification.get("idv_enEDjZD5sX6pUM",
+               test_api_host: api_host,
+               client_id: "123",
+               secret: "abc"
+             )
+  end
+
+  test "/identity_verification/list", %{bypass: bypass, api_host: api_host} do
+    Bypass.expect_once(bypass, "POST", "/identity_verification/list", fn conn ->
+      Conn.resp(
+        conn,
+        200,
+        ~s<{
+        "identity_verifications": [> <>
+          identity_verification_raw_response() <>
+          ~s<],
+        "next_cursor": null,
+        "request_id": "MCUHDbWmCJap0Fb"
+      }>
+      )
+    end)
+
+    assert {:ok,
+            %Plaid.IdentityVerification.ListResponse{
+              identity_verifications: [parsed_identity_verification()],
+              next_cursor: nil,
+              request_id: "MCUHDbWmCJap0Fb"
+            }} ==
+             Plaid.IdentityVerification.list(
+               %{template_id: "idvtmp_4iwgqud9uH1BS7", client_user_id: "user-id-202409051444"},
+               test_api_host: api_host,
+               client_id: "123",
+               secret: "abc"
+             )
+  end
+
+  test "/identity_verification/retry", %{bypass: bypass, api_host: api_host} do
+    previous_attempt_id = "flwses_enEDjZD5sX6pUM"
+
+    Bypass.expect_once(bypass, "POST", "/identity_verification/retry", fn conn ->
+      Conn.resp(conn, 200, identity_verification_raw_response(previous_attempt_id))
+    end)
+
+    assert {:ok,
+            Map.put(parsed_identity_verification(), :previous_attempt_id, previous_attempt_id)} ==
+             Plaid.IdentityVerification.retry(
+               %{
+                 client_user_id: "user-id-202409051444",
+                 template_id: "idvtmp_4iwgqud9uH1BS7",
+                 strategy: "reset",
+                 user: %{
+                   email_address: "acharleston@email.com",
+                   phone_number: "+14155550010",
+                   date_of_birth: "1975-01-18",
+                   name: %{
+                     given_name: "Anna",
+                     family_name: "Charleston"
+                   },
+                   address: %{
+                     street: "100 Market Street",
+                     street2: "Apt 1A",
+                     city: "San Francisco",
+                     region: "CA",
+                     postal_code: "94103",
+                     country: "US"
+                   },
+                   id_number: %{
+                     value: "123456789",
+                     type: "us_ssn"
+                   }
+                 }
+               },
+               test_api_host: api_host,
+               client_id: "123",
+               secret: "abc"
+             )
+  end
+
+  defp identity_verification_raw_response(previous_attempt_id \\ nil) do
+    ~s<{
+      "client_user_id": "user-id-202409051444",
+      "completed_at": null,
+      "created_at": "2024-09-05T21:47:05Z",
+      "documentary_verification": null,
+      "id": "idv_enEDjZD5sX6pUM",
+      "kyc_check": null,
+      "previous_attempt_id": > <>
+      if(is_nil(previous_attempt_id),
+        do: "null",
+        else: "\"#{previous_attempt_id}\""
+      ) <>
+      ~s<,
+      "redacted_at": null,
+      "request_id": "ND2MISjfi2ERTKB",
+      "risk_check": null,
+      "selfie_check": null,
+      "shareable_url": "https://verify-sandbox.plaid.com/verify/idv_enEDjZD5sX6pUM?key=1715da5b74d63e4784aeefaac9ea3124",
+      "status": "active",
+      "steps": {
+        "accept_tos": "skipped",
+        "documentary_verification": "not_applicable",
+        "kyc_check": "waiting_for_prerequisite",
+        "risk_check": "waiting_for_prerequisite",
+        "selfie_check": "not_applicable",
+        "verify_sms": "active",
+        "watchlist_screening": "waiting_for_prerequisite"
+      },
+      "template": {
+        "id": "idvtmp_4iwgqud9uH1BS7",
+        "version": 4
+      },
+      "user": {
+        "address": {
+          "city": "San Francisco",
+          "country": "US",
+          "postal_code": "94103",
+          "region": "CA",
+          "street": "100 Market Street",
+          "street2": "Apt 1A"
+        },
+        "date_of_birth": "1975-01-18",
+        "email_address": "acharleston@email.com",
+        "id_number": {
+          "type": "us_ssn",
+          "value": "123456789"
+        },
+        "ip_address": null,
+        "name": {
+          "family_name": "Charleston",
+          "given_name": "Anna"
+        },
+        "phone_number": "+14155550010"
+      },
+      "watchlist_screening_id": null
+    }>
+  end
+
+  defp parsed_identity_verification do
+    %Plaid.IdentityVerification{
+      id: "idv_enEDjZD5sX6pUM",
+      client_user_id: "user-id-202409051444",
+      created_at: "2024-09-05T21:47:05Z",
+      completed_at: nil,
+      previous_attempt_id: nil,
+      shareable_url:
+        "https://verify-sandbox.plaid.com/verify/idv_enEDjZD5sX6pUM?key=1715da5b74d63e4784aeefaac9ea3124",
+      template: %Plaid.IdentityVerification.Template{
+        id: "idvtmp_4iwgqud9uH1BS7",
+        version: 4
+      },
+      user: %Plaid.IdentityVerification.User{
+        phone_number: "+14155550010",
+        date_of_birth: "1975-01-18",
+        ip_address: nil,
+        email_address: "acharleston@email.com",
+        name: %Plaid.IdentityVerification.User.Name{
+          given_name: "Anna",
+          family_name: "Charleston"
+        },
+        address: %Plaid.IdentityVerification.User.Address{
+          street: "100 Market Street",
+          street2: "Apt 1A",
+          city: "San Francisco",
+          region: "CA",
+          postal_code: "94103",
+          country: "US"
+        },
+        id_number: %Plaid.IdentityVerification.User.IdNumber{
+          value: "123456789",
+          type: "us_ssn"
+        }
+      },
+      status: "active",
+      steps: %Plaid.IdentityVerification.Steps{
+        accept_tos: "skipped",
+        verify_sms: "active",
+        kyc_check: "waiting_for_prerequisite",
+        documentary_verification: "not_applicable",
+        selfie_check: "not_applicable",
+        watchlist_screening: "waiting_for_prerequisite",
+        risk_check: "waiting_for_prerequisite"
+      },
+      documentary_verification: nil,
+      selfie_check: nil,
+      kyc_check: nil,
+      risk_check: nil,
+      watchlist_screening_id: nil,
+      redacted_at: nil,
+      request_id: "ND2MISjfi2ERTKB"
+    }
+  end
+end

--- a/test/plaid/webhooks_test.exs
+++ b/test/plaid/webhooks_test.exs
@@ -401,6 +401,35 @@ defmodule Plaid.WebhooksTest do
         )
     end
 
+    test "identity verification webhooks", %{api_host: api_host} do
+      for code <- ["STATUS_UPDATED", "STEP_UPDATED", "RETRIED"] do
+        raw_body =
+          ~s<{
+               "webhook_type": "IDENTITY_VERIFICATION",
+               "webhook_code": "> <>
+            code <>
+            ~s<",
+               "identity_verification_id": "idv_52xR9LKo77r1Np",
+               "environment": "production"
+             }>
+
+        jwt = create_jwt(raw_body)
+
+        assert {:ok,
+                %Plaid.Webhooks.IdentityVerification{
+                  webhook_type: "IDENTITY_VERIFICATION",
+                  webhook_code: ^code,
+                  identity_verification_id: "idv_52xR9LKo77r1Np",
+                  environment: "production"
+                }} =
+                 Plaid.Webhooks.verify_and_construct(jwt, raw_body,
+                   client_id: "abc",
+                   secret: "123",
+                   test_api_host: api_host
+                 )
+      end
+    end
+
     test "investments transactions default update webhook", %{api_host: api_host} do
       raw_body =
         ~s<{"webhook_type": "INVESTMENTS_TRANSACTIONS", "webhook_code": "DEFAULT_UPDATE", "item_id": "wz666MBjYWTp2PDzzggYhM6oWWmBb", "error": null, "new_investments_transactions": 16, "canceled_investments_transactions": 0}>


### PR DESCRIPTION
I'd like to use Plaid's Identity Verification product, so I've added basic support for it. This PR basically just provides structs to wrap the return values from the `/identity_verification/...` endpoints and associated webhooks.

The tests are a little lacking, since they don't include all the details of these structs. I made queries against the Plaid sandbox to get an idea of their response data, but I wasn't able to get the meatier stuff like `documentary_verification` to appear. Presumably my template isn't configured for every feature Plaid offers; I'll update the tests here if I successfully update my template to include more checks.

Thanks for taking a look!