### PR TITLE
Sync transactions support

### DIFF
--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -14,9 +14,11 @@ defmodule Plaid.Item do
           error: Plaid.Error.t() | nil,
           has_perpetual_otp: boolean(),
           institution_id: String.t() | nil,
+          institution_name: String.t() | nil,
           item_id: String.t(),
           update_type: String.t(),
-          webhook: String.t() | nil
+          webhook: String.t() | nil,
+          auth_method: String.t() | nil
         }
 
   defstruct [
@@ -26,9 +28,11 @@ defmodule Plaid.Item do
     :has_perpetual_otp,
     :error,
     :institution_id,
+    :institution_name,
     :item_id,
     :update_type,
-    :webhook
+    :webhook,
+    :auth_method
   ]
 
   @impl true
@@ -40,9 +44,11 @@ defmodule Plaid.Item do
       error: Castable.cast(Plaid.Error, generic_map["error"]),
       has_perpetual_otp: generic_map["has_perpetual_otp"],
       institution_id: generic_map["institution_id"],
+      institution_name: generic_map["institution_name"],
       item_id: generic_map["item_id"],
       update_type: generic_map["update_type"],
-      webhook: generic_map["webhook"]
+      webhook: generic_map["webhook"],
+      auth_method: generic_map["auth_method"]
     }
   end
 
@@ -156,7 +162,7 @@ defmodule Plaid.Item do
   Update a webhook for an access_token.
 
   Does a `POST /item/webhook/update` call which is used to update webhook
-  for a particular access_token.
+  for a particular access_token. 
 
   ## Params
 
@@ -275,7 +281,7 @@ defmodule Plaid.Item do
   @doc """
   Invalidate an access token.
 
-  Does a `POST /item/access_token/invalidate` call which rotates an access token
+  Does a `POST /item/access_token/invalidate` call which rotates an access token 
   for an item. Immediately invalidating it and returning a new access token.
 
   ## Params

--- a/lib/plaid/transactions.ex
+++ b/lib/plaid/transactions.ex
@@ -125,7 +125,9 @@ defmodule Plaid.Transactions do
   def sync(access_token, options \\ %{}, config) do
     params_payload = Map.take(options, [:cursor, :count])
     options_payload = Map.take(options, [:include_original_description, :days_requested, :account_id])
-    payload = params_payload |> Map.put(:options, options_payload)
+    payload = params_payload
+      |> Map.put(:options, options_payload)
+      |> Map.put(:access_token, access_token)
 
     Plaid.Client.call(
              "/transactions/sync",

--- a/lib/plaid/transactions.ex
+++ b/lib/plaid/transactions.ex
@@ -3,6 +3,56 @@ defmodule Plaid.Transactions do
   [Plaid Transactions API](https://plaid.com/docs/api/transactions) calls and schema.
   """
 
+  defmodule SyncResponse do
+    @moduledoc """
+    [Plaid API /transactions/sync response schema.](https://plaid.com/docs/api/products/transactions/#transactionssync)
+    """
+
+    @behaviour Castable
+
+    alias Plaid.{Castable, Account, Transactions}
+
+    @type t :: %__MODULE__{
+            transactions_update_status: binary(),
+            accounts: [Account.t()],
+            added: [Transactions.Transaction.t()],
+            modified: [Transactions.Transaction.t()],
+            removed: [Transactions.Transaction.t()],
+            next_cursor: binary(),
+            has_more: boolean(),
+            request_id: String.t(),
+            access_token: String.t() | nil
+          }
+
+    defstruct [
+      :transactions_update_status,
+      :accounts,
+      :added,
+      :modified,
+      :removed,
+      :next_cursor,
+      :has_more,
+      :request_id,
+      :access_token
+    ]
+
+    @impl true
+    def cast(generic_map) do
+      %__MODULE__{
+        transactions_update_status: generic_map["transactions_update_status"],
+        accounts: Castable.cast_list(Account, generic_map["accounts"]),
+        added: Castable.cast_list(Transactions.SyncedTransaction, generic_map["added"]),
+        modified: Castable.cast_list(Transactions.SyncedTransaction, generic_map["modified"]),
+        removed:
+          Castable.cast_list(Transactions.RemovedSyncedTransaction, generic_map["removed"]),
+        next_cursor: generic_map["next_cursor"],
+        has_more: generic_map["has_more"],
+        request_id: generic_map["request_id"],
+        access_token: generic_map["access_token"]
+      }
+    end
+  end
+
   defmodule GetResponse do
     @moduledoc """
     [Plaid API /transactions/get response schema.](https://plaid.com/docs/api/transactions)
@@ -41,6 +91,41 @@ defmodule Plaid.Transactions do
         request_id: generic_map["request_id"]
       }
     end
+  end
+
+  @doc """
+  Sync the latest transactions.
+
+  Does a `POST /transactions/sync` call, which gives you details on transactions
+  that have been added, modified, and removed relative to the update indicated
+  by `cursor`.
+
+  Params:
+  * `access_token` - Token to fetch transactions for.
+
+  Options:
+  * `:cursor`                       - Opaque token pointing to an update, after which all newly
+                                      added, modified, and removed transactions will be returned.
+  * `:count`                        - Number of transactions to pull (min 1, max 500, default 100).
+  * `:include_original_description` - Include the raw unparsed transaction description from the
+                                      financial institution.
+  * `:days_requested`               - Maximum number of days of transaction history (only applies
+                                      to calls for Items where the Transactions product has not
+                                      already been initialized).
+  * `:account_id`                   - Specific account id for which to fetch balances.
+  """
+  @spec sync(String.t(), options, Plaid.config()) :: {:ok, SyncResponse.t()} | {:error, Plaid.Error.t()}
+  def sync(access_token, options \\ %{}, config) do
+    params_payload = Map.take(options, [:cursor, :count])
+    options_payload = Map.take(options, [:include_original_description, :days_requested, :account_id])
+    payload = params_payload |> Map.put(:options, options_payload)
+
+    Plaid.Client.call(
+             "/transactions/sync",
+             payload,
+             Plaid.Transactions.SyncResponse,
+             config
+           )
   end
 
   @doc """

--- a/lib/plaid/transactions.ex
+++ b/lib/plaid/transactions.ex
@@ -115,6 +115,13 @@ defmodule Plaid.Transactions do
   * `:account_id`                   - Specific account id for which to fetch balances.
   """
   @spec sync(String.t(), options, Plaid.config()) :: {:ok, SyncResponse.t()} | {:error, Plaid.Error.t()}
+  when options: %{
+               optional(:cursor) => String.t(),
+               optional(:count) => integer(),
+               optional(:include_original_description) => boolean(),
+               optional(:days_requested) => integer(),
+               optional(:account_id) => String.t(),
+             }
   def sync(access_token, options \\ %{}, config) do
     params_payload = Map.take(options, [:cursor, :count])
     options_payload = Map.take(options, [:include_original_description, :days_requested, :account_id])

--- a/lib/plaid/transactions/removed_synced_transaction.ex
+++ b/lib/plaid/transactions/removed_synced_transaction.ex
@@ -1,0 +1,27 @@
+defmodule Plaid.Transactions.RemovedSyncedTransaction do
+  @moduledoc """
+  [Plaid removed synced transaction schema.](https://plaid.com/docs/api/products/transactions/#transactionssync)
+  """
+
+  @behaviour Plaid.Castable
+
+  alias Plaid.Castable
+
+  @type t :: %__MODULE__{
+          transaction_id: String.t(),
+          account_id: String.t()
+        }
+
+  defstruct [
+    :account_id,
+    :transaction_id
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      account_id: generic_map["account_id"],
+      transaction_id: generic_map["transaction_id"]
+    }
+  end
+end

--- a/lib/plaid/transactions/synced_transaction.ex
+++ b/lib/plaid/transactions/synced_transaction.ex
@@ -1,0 +1,109 @@
+defmodule Plaid.Transactions.SyncedTransaction do
+  @moduledoc """
+  [Plaid Synced Transaction schema.](https://plaid.com/docs/api/products/transactions/#transactionssync)
+  """
+
+  @behaviour Plaid.Castable
+
+  alias Plaid.Transactions.Transaction.PersonalFinanceCategory
+  alias Plaid.Castable
+  alias Plaid.Transactions.Transaction.{Location, PaymentMeta}
+  alias Plaid.Transactions.SyncedTransaction.{Counterparty, PersonalFinanceCategory}
+
+  @type t :: %__MODULE__{
+          account_id: String.t(),
+          amount: number(),
+          iso_currency_code: String.t() | nil,
+          unofficial_currency_code: String.t() | nil,
+          check_number: String.t() | nil,
+          date: String.t(),
+          authorized_date: String.t() | nil,
+          authorized_datetime: String.t() | nil,
+          location: Location.t(),
+          name: String.t(),
+          merchant_name: String.t() | nil,
+          payment_meta: PaymentMeta.t(),
+          payment_channel: String.t(),
+          pending: boolean(),
+          pending_transaction_id: String.t() | nil,
+          account_owner: String.t() | nil,
+          transaction_id: String.t(),
+          transaction_code: String.t() | nil,
+          transaction_type: String.t(),
+          logo_url: String.t() | nil,
+          website: String.t() | nil,
+          datetime: String.t() | nil,
+          personal_finance_category: PersonalFinanceCategory.t() | nil,
+          personal_finance_category_icon_url: String.t(),
+          counterparties: [CounterParty.t()],
+          merchant_id: String.t() | nil,
+          date_transacted: String.t() | nil,
+          original_description: String.t() | nil
+        }
+
+  defstruct [
+    :account_id,
+    :amount,
+    :iso_currency_code,
+    :unofficial_currency_code,
+    :check_number,
+    :date,
+    :authorized_date,
+    :authorized_datetime,
+    :location,
+    :name,
+    :merchant_name,
+    :payment_meta,
+    :payment_channel,
+    :pending,
+    :pending_transaction_id,
+    :account_owner,
+    :transaction_id,
+    :transaction_code,
+    :transaction_type,
+    :logo_url,
+    :website,
+    :datetime,
+    :personal_finance_category,
+    :personal_finance_category_icon_url,
+    :counterparties,
+    :merchant_id,
+    :date_transacted,
+    :original_description
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      account_id: generic_map["account_id"],
+      amount: generic_map["amount"],
+      iso_currency_code: generic_map["iso_currency_code"],
+      unofficial_currency_code: generic_map["unofficial_currency_code"],
+      check_number: generic_map["check_number"],
+      date: generic_map["date"],
+      authorized_date: generic_map["authorized_date"],
+      authorized_datetime: generic_map["authorized_datetime"],
+      location: Castable.cast(Location, generic_map["location"]),
+      name: generic_map["name"],
+      merchant_name: generic_map["merchant_name"],
+      payment_meta: Castable.cast(PaymentMeta, generic_map["payment_meta"]),
+      payment_channel: generic_map["payment_channel"],
+      pending: generic_map["pending"],
+      pending_transaction_id: generic_map["pending_transaction_id"],
+      account_owner: generic_map["account_owner"],
+      transaction_id: generic_map["transaction_id"],
+      transaction_code: generic_map["transaction_code"],
+      transaction_type: generic_map["transaction_type"],
+      logo_url: generic_map["logo_url"],
+      website: generic_map["website"],
+      datetime: generic_map["datetime"],
+      personal_finance_category:
+        Castable.cast(PersonalFinanceCategory, generic_map["personal_finance_category"]),
+      personal_finance_category_icon_url: generic_map["personal_finance_category_icon_url"],
+      counterparties: Castable.cast_list(Counterparty, generic_map["counterparties"]),
+      merchant_id: generic_map["merchant_id"],
+      date_transacted: generic_map["date_transacted"],
+      original_description: generic_map["original_description"]
+    }
+  end
+end

--- a/lib/plaid/transactions/synced_transaction/counterparty.ex
+++ b/lib/plaid/transactions/synced_transaction/counterparty.ex
@@ -1,0 +1,39 @@
+defmodule Plaid.Transactions.SyncedTransaction.Counterparty do
+  @moduledoc """
+  [Plaid counterparty schema.](https://plaid.com/docs/api/products/transactions/#transactionssync)
+  """
+
+  @behaviour Plaid.Castable
+
+  alias Plaid.Castable
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          entity_id: String.t() | nil,
+          type: String.t(),
+          website: String.t() | nil,
+          logo_url: String.t() | nil,
+          confidence_level: String.t() | nil
+        }
+
+  defstruct [
+    :name,
+    :entity_id,
+    :type,
+    :website,
+    :logo_url,
+    :confidence_level
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      name: generic_map["primary"],
+      entity_id: generic_map["entity_id"],
+      type: generic_map["type"],
+      website: generic_map["website"],
+      logo_url: generic_map["logo_url"],
+      confidence_level: generic_map["confidence_level"]
+    }
+  end
+end

--- a/lib/plaid/transactions/synced_transaction/personal_finance_category.ex
+++ b/lib/plaid/transactions/synced_transaction/personal_finance_category.ex
@@ -1,0 +1,30 @@
+defmodule Plaid.Transactions.SyncedTransaction.PersonalFinanceCategory do
+  @moduledoc """
+  [Plaid counterparty schema.](https://plaid.com/docs/api/products/transactions/#transactionssync)
+  """
+
+  @behaviour Plaid.Castable
+
+  alias Plaid.Castable
+
+  @type t :: %__MODULE__{
+          primary: String.t(),
+          detailed: String.t(),
+          confidence_level: String.t() | nil
+        }
+
+  defstruct [
+    :primary,
+    :detailed,
+    :confidence_level
+  ]
+
+  @impl true
+  def cast(generic_map) do
+    %__MODULE__{
+      primary: generic_map["primary"],
+      detailed: generic_map["detailed"],
+      confidence_level: generic_map["confidence_level"]
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plaid.MixProject do
   def project do
     [
       app: :elixir_plaid,
-      version: "1.2.1",
+      version: "1.3.0",
       description: description(),
       package: package(),
       elixir: "~> 1.10",


### PR DESCRIPTION
This PR:

- Introduces support for the [/transactions/sync](https://plaid.com/docs/api/products/transactions/#transactionssync) API
- Updates the [/item/get](https://plaid.com/docs/api/items/#itemget) API

Get transactions API has been deprecated for a while, so this PR helps this library be more suitable for greenfield projects 👍 

Thanks for your work, @tylerwray!